### PR TITLE
Accidentally removed the conditional hide attribute for the use time variable

### DIFF
--- a/Runtime/Enemy/EnemyManager.cs
+++ b/Runtime/Enemy/EnemyManager.cs
@@ -44,6 +44,7 @@ namespace Enemy
 		[ConditionalHide(true, false, "spawnMode", "spawnSystem", "increaseEnemiesPerRound")]
 		[Min(1)]
 		public int numberToIncreasePerRound = 1;
+		[ConditionalHide(true, false, "spawnMode", "spawnSystem")]
 		public bool useTime;
 		[ConditionalHide(true, false, "spawnMode", "useTime", "spawnSystem")]
 		[Min(1)]


### PR DESCRIPTION
Accidentally removed the conditional hide attribute for the use time variable